### PR TITLE
Improved extraction of package's version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,14 @@
+import io
+import re
+
 from setuptools import setup
-from pyexasol.version import __version__
+
+with io.open('pyexasol/version.py', 'rt', encoding='utf8') as f:
+    version = re.search(r'__version__ = \'(.*?)\'', f.read()).group(1)
 
 setup(
     name='pyexasol',
-    version=__version__,
+    version=version,
     description='Exasol python driver with extra features',
     long_description="""
 Exasol python driver with low overhead, fast HTTP transport and compression.


### PR DESCRIPTION
by importing the `pyexasol` package itself in `setup.py` will fail if the required dependencies are not installed.

This change reads the version of the `pyexasol` package without triggering the import of `__init__.py` and causing the dependencies failure.