### PR TITLE
Use environment variables for example's settings

### DIFF
--- a/examples/_config.py
+++ b/examples/_config.py
@@ -1,4 +1,6 @@
-dsn = 'exasol-dev.mlan:8563'
-user = 'SYS'
-password = 'exasol'
-schema = 'PYEXASOL_TEST'
+import os
+
+dsn = os.environ.get('EXA_HOST') or 'localhost:8563'
+user = os.environ.get('EXA_USER') or 'SYS'
+password = os.environ.get('EXA_PWD') or 'exasol'
+schema = os.environ.get('EXA_SCHEMA') or 'PYEXASOL_TEST'


### PR DESCRIPTION
Settings in the `examples` directory are very specific but we want to allow the users to use their settings without changing the code.