### PR TITLE
Added Python 3.7 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache: pip
 
 python:
     - 3.6
+    - 3.7-dev
 
 sudo: required
 


### PR DESCRIPTION
In the meanwhile we are waiting for Travis to support Python 3.7 we can test the code against 3.7-dev