### PR TITLE
Updated Travis for Python 3.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,12 @@ language: python
 
 cache: pip
 
-python:
-    - 3.6
-    - 3.7-dev
+matrix:
+    include:
+        -   python: 3.6
+        -   python: 3.7
+            sudo: required
+            dist: xenial
 
 sudo: required
 


### PR DESCRIPTION
Uses Python 3.7 stable instead of the dev version