### PR TITLE
Fix concurrency issue in ExaConnection req method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ build/
 
 # Visual Studio Code
 .vscode
+
+venv

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,3 +68,4 @@ script:
     - python examples/23_snapshot_transactions.py
   # - python examples/24_script_output.py  disabled due to connectivity problems
     - python examples/25_overload.py
+    - python tests/test_concurrent_queries.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,3 +69,4 @@ script:
   # - python examples/24_script_output.py  disabled due to connectivity problems
     - python examples/25_overload.py
     - python tests/test_concurrent_queries.py
+    - python tests/test_threadsafety_peformance.py

--- a/pyexasol/exceptions.py
+++ b/pyexasol/exceptions.py
@@ -1,3 +1,5 @@
+import threading
+
 
 class ExaError(Exception):
     def __init__(self, connection, message):
@@ -65,3 +67,16 @@ class ExaQueryError(ExaRequestError):
 
 class ExaQueryTimeoutError(ExaQueryError):
     pass
+
+class ExaConcurrencyError(ExaError):
+    def __init__(self, connection, message):
+        self.current_thread = threading.get_ident()
+
+        super().__init__(connection, message)
+
+    def get_params_for_print(self):
+        params = super().get_params_for_print()
+        params['owning_thread'] = self.connection.owning_thread
+        params['current_thread'] = self.current_thread
+
+        return params

--- a/pyexasol/http_transport.py
+++ b/pyexasol/http_transport.py
@@ -119,7 +119,7 @@ class ExaSQLExportThread(ExaSQLThread):
         if self.params.get('with_column_names'):
             query += '\nWITH COLUMN NAMES'
 
-        self.connection.execute(query)
+        self.connection._execute_without_lock(query)
 
 
 class ExaSQLImportThread(ExaSQLThread):
@@ -162,7 +162,7 @@ class ExaSQLImportThread(ExaSQLThread):
         if self.params.get('column_delimiter'):
             query += '\nCOLUMN DELIMITER = ' + self.connection.format.quote(self.params['column_delimiter'])
 
-        self.connection.execute(query)
+        self.connection._execute_without_lock(query)
 
 
 class ExaHTTPProcess(object):

--- a/tests/test_concurrent_queries.py
+++ b/tests/test_concurrent_queries.py
@@ -1,0 +1,134 @@
+import time
+import unittest
+from typing import List
+
+import pyexasol
+import examples._config as config
+from pyexasol import ExaQueryError
+import threading
+
+THREAD_COUNT = 5
+QUERY_COUNT_PER_THREAD = 3
+
+class TestConcurrentQueries(unittest.TestCase):
+    def execute_udf_sleep(self, C, result):
+        try:
+            stmt = C.execute("select sleep(1.0);")
+            result.append("OK")
+        except ExaQueryError as e:
+            result.append(e.message)
+        except Exception as e:
+            result.append(str(e))
+
+    def test_concurrent_executes(self):
+        C = pyexasol.connect(dsn=config.dsn, user=config.user, password=config.password, autocommit=False)
+        try:
+            C.execute("CREATE SCHEMA IF NOT EXISTS {schema!i}", {'schema': config.schema})
+            C.open_schema(config.schema)
+
+            stmt = C.execute("""
+            CREATE OR REPLACE PYTHON SET SCRIPT SLEEP(test double)
+            EMITS (test double) AS
+    
+            def run(ctx):
+                import time
+                time.sleep( 10 )
+            \
+            """)
+
+            result = []
+            t1 = threading.Thread(target=self.execute_udf_sleep, args=(C, result))
+            t1.start()
+            time.sleep(1) # wait for statement in thread to start
+            stmt = C.execute("select 1;")
+            t1.join()
+            self.assertEqual(result[0],"OK")
+        finally:
+            C.close()
+
+    def export_pandas_udf_sleep(self, C, result):
+        try:
+            stmt = C.export_to_pandas("select sleep(1.0);")
+            result.append("OK")
+        except ExaQueryError as e:
+            result.append(e.message)
+        except Exception as e:
+            result.append(str(e))
+
+    def test_concurrent_export_pandas(self):
+        C = pyexasol.connect(dsn=config.dsn, user=config.user, password=config.password, autocommit=False)
+        try:
+            # Create schema if not exist and open it
+            C.execute("CREATE SCHEMA IF NOT EXISTS {schema!i}", {'schema': config.schema})
+            C.open_schema(config.schema)
+
+            stmt = C.execute("""
+            CREATE OR REPLACE PYTHON SET SCRIPT SLEEP(test double)
+            EMITS (test double) AS
+
+            def run(ctx):
+                import time
+                time.sleep( 10 )
+            \
+            """,{'schema': config.schema})
+
+            result = []
+            t1 = threading.Thread(target=self.export_pandas_udf_sleep, args=(C, result))
+            t1.start()
+            time.sleep(1)  # wait for statement in thread to start
+            stmt = C.export_to_pandas("select 1;")
+            t1.join()
+            self.assertEqual(result[0], "OK")
+        finally:
+            C.close()
+
+
+    def execute_udf_sleep_print_id(self, C, thread_id, result):
+        try:
+            for query_id in range(QUERY_COUNT_PER_THREAD):
+                print("Before Execute Thread %s Query %s" % (thread_id, query_id))
+                stmt = C.execute("select sleep(1.0);")
+                print("After Execute Thread %s Query %s" % (thread_id, query_id))
+            result.append("OK")
+        except ExaQueryError as e:
+            result.append(e.message)
+        except Exception as e:
+            result.append(str(e))
+
+    def test_many_concurrent_queries(self):
+        C = pyexasol.connect(dsn=config.dsn, user=config.user, password=config.password, autocommit=False)
+        try:
+            C.execute("CREATE SCHEMA IF NOT EXISTS {schema!i}", {'schema': config.schema})
+            C.open_schema(config.schema)
+
+            stmt = C.execute("""
+            CREATE OR REPLACE PYTHON SET SCRIPT SLEEP(test double)
+            EMITS (test double) AS
+    
+            def run(ctx):
+                import time
+                time.sleep( 1 )
+            \
+            """)
+            threads = []
+
+            results_of_threads = []
+            for thread_id in range(THREAD_COUNT):
+                result = []
+                results_of_threads.append(result)
+                thread = threading.Thread(target=self.execute_udf_sleep_print_id, args=(C, thread_id, result))
+                threads.append(thread)
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+            self.assertSequenceEqual(
+                [result[0] for result in results_of_threads],
+                ["OK" for thread_id in results_of_threads],
+                List
+            )
+        finally:
+            C.close()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_concurrent_queries.py
+++ b/tests/test_concurrent_queries.py
@@ -4,8 +4,11 @@ from typing import List
 
 import pyexasol
 import examples._config as config
-from pyexasol import ExaQueryError
 import threading
+import pandas as pd
+import numpy as np
+
+from pyexasol.exceptions import ExaConcurrencyError
 
 THREAD_COUNT = 5
 QUERY_COUNT_PER_THREAD = 3
@@ -14,9 +17,9 @@ class TestConcurrentQueries(unittest.TestCase):
     def execute_udf_sleep(self, C, result):
         try:
             stmt = C.execute("select sleep(1.0);")
+            result.append("ERROR: Other thread used connection")
+        except ExaConcurrencyError as e:
             result.append("OK")
-        except ExaQueryError as e:
-            result.append(e.message)
         except Exception as e:
             result.append(str(e))
 
@@ -49,9 +52,9 @@ class TestConcurrentQueries(unittest.TestCase):
     def export_pandas_udf_sleep(self, C, result):
         try:
             stmt = C.export_to_pandas("select sleep(1.0);")
+            result.append("ERROR: Other thread used connection")
+        except ExaConcurrencyError as e:
             result.append("OK")
-        except ExaQueryError as e:
-            result.append(e.message)
         except Exception as e:
             result.append(str(e))
 
@@ -70,7 +73,7 @@ class TestConcurrentQueries(unittest.TestCase):
                 import time
                 time.sleep( 10 )
             \
-            """,{'schema': config.schema})
+            """)
 
             result = []
             t1 = threading.Thread(target=self.export_pandas_udf_sleep, args=(C, result))
@@ -82,51 +85,37 @@ class TestConcurrentQueries(unittest.TestCase):
         finally:
             C.close()
 
-
-    def execute_udf_sleep_print_id(self, C, thread_id, result):
+    def import_pandas(self, C, df, result):
         try:
-            for query_id in range(QUERY_COUNT_PER_THREAD):
-                print("Before Execute Thread %s Query %s" % (thread_id, query_id))
-                stmt = C.execute("select sleep(1.0);")
-                print("After Execute Thread %s Query %s" % (thread_id, query_id))
+            stmt = C.import_from_pandas(df,"test")
+            result.append("ERROR: Other thread used connection")
+        except ExaConcurrencyError as e:
             result.append("OK")
-        except ExaQueryError as e:
-            result.append(e.message)
         except Exception as e:
             result.append(str(e))
 
-    def test_many_concurrent_queries(self):
+    def test_concurrent_import_pandas(self):
         C = pyexasol.connect(dsn=config.dsn, user=config.user, password=config.password, autocommit=False)
         try:
+            # Create schema if not exist and open it
             C.execute("CREATE SCHEMA IF NOT EXISTS {schema!i}", {'schema': config.schema})
             C.open_schema(config.schema)
 
-            stmt = C.execute("""
-            CREATE OR REPLACE PYTHON SET SCRIPT SLEEP(test double)
-            EMITS (test double) AS
-    
-            def run(ctx):
-                import time
-                time.sleep( 1 )
-            \
+            stmt = C.execute(f"""
+            CREATE OR REPLACE TABLE test(
+              {",".join(["c%s double"%i for i in range(10)])}
+            );
             """)
-            threads = []
+            df = pd.DataFrame(np.zeros(shape=[100000,10]),columns=["c%s"%i for i in range(10)])
 
-            results_of_threads = []
-            for thread_id in range(THREAD_COUNT):
-                result = []
-                results_of_threads.append(result)
-                thread = threading.Thread(target=self.execute_udf_sleep_print_id, args=(C, thread_id, result))
-                threads.append(thread)
-            for thread in threads:
-                thread.start()
-            for thread in threads:
-                thread.join()
-            self.assertSequenceEqual(
-                [result[0] for result in results_of_threads],
-                ["OK" for thread_id in results_of_threads],
-                List
-            )
+            result = []
+            t1 = threading.Thread(target=self.import_pandas, args=(C, df, result))
+            t1.start()
+            time.sleep(1)  # wait for statement in thread to start
+            stmt = C.import_from_pandas(df,"test")
+            t1.join()
+            self.assertEqual(result[0], "OK")
+            self.assertEqual(C.execute("select count(1) from test;").fetchval(),100000)
         finally:
             C.close()
 

--- a/tests/test_concurrent_queries.py
+++ b/tests/test_concurrent_queries.py
@@ -24,7 +24,7 @@ class TestConcurrentQueries(unittest.TestCase):
             result.append(str(e))
 
     def test_concurrent_executes(self):
-        C = pyexasol.connect(dsn=config.dsn, user=config.user, password=config.password, autocommit=False)
+        C = pyexasol.connect(dsn=config.dsn, user=config.user, password=config.password, autocommit=False, threadsafety=1)
         try:
             C.execute("CREATE SCHEMA IF NOT EXISTS {schema!i}", {'schema': config.schema})
             C.open_schema(config.schema)
@@ -35,7 +35,7 @@ class TestConcurrentQueries(unittest.TestCase):
     
             def run(ctx):
                 import time
-                time.sleep( 10 )
+                time.sleep( 5 )
             \
             """)
 
@@ -59,7 +59,7 @@ class TestConcurrentQueries(unittest.TestCase):
             result.append(str(e))
 
     def test_concurrent_export_pandas(self):
-        C = pyexasol.connect(dsn=config.dsn, user=config.user, password=config.password, autocommit=False)
+        C = pyexasol.connect(dsn=config.dsn, user=config.user, password=config.password, autocommit=False, threadsafety=1)
         try:
             # Create schema if not exist and open it
             C.execute("CREATE SCHEMA IF NOT EXISTS {schema!i}", {'schema': config.schema})
@@ -71,7 +71,7 @@ class TestConcurrentQueries(unittest.TestCase):
 
             def run(ctx):
                 import time
-                time.sleep( 10 )
+                time.sleep( 5 )
             \
             """)
 
@@ -94,8 +94,10 @@ class TestConcurrentQueries(unittest.TestCase):
         except Exception as e:
             result.append(str(e))
 
+
     def test_concurrent_import_pandas(self):
-        C = pyexasol.connect(dsn=config.dsn, user=config.user, password=config.password, autocommit=False)
+        C = pyexasol.connect(dsn=config.dsn, user=config.user, password=config.password, autocommit=False,
+                             threadsafety=1)
         try:
             # Create schema if not exist and open it
             C.execute("CREATE SCHEMA IF NOT EXISTS {schema!i}", {'schema': config.schema})

--- a/tests/test_threadsafety_peformance.py
+++ b/tests/test_threadsafety_peformance.py
@@ -1,0 +1,92 @@
+import pyexasol
+import examples._config as config
+import pandas as pd
+import numpy as np
+
+
+def test_peformance_execute(threadsafety, query_count):
+    C = pyexasol.connect(dsn=config.dsn, user=config.user, password=config.password, autocommit=False,
+                         threadsafety=threadsafety)
+    try:
+        for i in range(query_count):
+            C.execute("select * from %s.test;" % config.schema).fetchall()
+    finally:
+        C.close()
+
+
+def test_peformance_export_to_pandas(threadsafety, query_count):
+    C = pyexasol.connect(dsn=config.dsn, user=config.user, password=config.password, autocommit=False,
+                         threadsafety=threadsafety)
+    try:
+        for i in range(query_count):
+            C.export_to_pandas("select * from %s.test;" % config.schema)
+    finally:
+        C.close()
+
+
+def setup():
+    C = pyexasol.connect(dsn=config.dsn, user=config.user, password=config.password, autocommit=False)
+    try:
+        # Create schema if not exist and open it
+        C.execute("CREATE SCHEMA IF NOT EXISTS {schema!i}", {'schema': config.schema})
+        C.open_schema(config.schema)
+
+        stmt = C.execute(f"""
+        CREATE OR REPLACE TABLE test(
+          {",".join(["c%s double" % i for i in range(10)])}
+        );
+        """)
+        # insert 10 rows, we only use this few, because we want to measure the overhead of the lock
+        df = pd.DataFrame(np.zeros(shape=[10, 10]), columns=["c%s" % i for i in range(10)])
+        stmt = C.import_from_pandas(df, (config.schema, "test"))
+        C.commit()
+    finally:
+        C.close()
+
+
+NUMBER_OF_EXECUTIONS = 1
+
+NUMBER_OF_REPEATS_FOR_EXECUTE = 10
+
+NUMBER_OF_REPEATS_FOR_EXPORT = 5
+
+NUMBER_OF_QUERIES_FOR_EXECUTE = 1000
+
+NUMBER_OF_QUERIES_FOR_EXPORT = 5
+
+NUMBER_OF_TIMINGS = 3
+
+if __name__ == "__main__":
+    import timeit
+
+    setup()
+    setup = "from __main__ import test_peformance_execute, test_peformance_export_to_pandas"
+    for i in range(NUMBER_OF_TIMINGS):
+        print("execute", "threadsafety==1 => on",
+              sum(timeit.repeat(
+                  "test_peformance_execute(1,%s)" % NUMBER_OF_QUERIES_FOR_EXECUTE,
+                  setup=setup,
+                  repeat=NUMBER_OF_REPEATS_FOR_EXECUTE,
+                  number=NUMBER_OF_EXECUTIONS))
+              / (NUMBER_OF_EXECUTIONS * NUMBER_OF_REPEATS_FOR_EXECUTE))
+        print("execute", "threadsafety==0 => off",
+              sum(timeit.repeat(
+                  "test_peformance_execute(0,%s)" % NUMBER_OF_QUERIES_FOR_EXECUTE,
+                  setup=setup,
+                  repeat=NUMBER_OF_REPEATS_FOR_EXECUTE,
+                  number=NUMBER_OF_EXECUTIONS))
+              / (NUMBER_OF_EXECUTIONS * NUMBER_OF_REPEATS_FOR_EXECUTE))
+        print("export_to_pandas", "threadsafety==1 => on",
+              sum(timeit.repeat(
+                  "test_peformance_export_to_pandas(1,%s)" % NUMBER_OF_QUERIES_FOR_EXPORT,
+                  setup=setup,
+                  repeat=NUMBER_OF_REPEATS_FOR_EXECUTE,
+                  number=NUMBER_OF_EXECUTIONS))
+              / (NUMBER_OF_EXECUTIONS * NUMBER_OF_REPEATS_FOR_EXECUTE))
+        print("export_to_pandas", "threadsafety==0 => off",
+              sum(timeit.repeat(
+                  "test_peformance_export_to_pandas(0,%s)" % NUMBER_OF_QUERIES_FOR_EXPORT,
+                  setup=setup,
+                  repeat=NUMBER_OF_REPEATS_FOR_EXECUTE,
+                  number=NUMBER_OF_EXECUTIONS))
+              / (NUMBER_OF_EXECUTIONS * NUMBER_OF_REPEATS_FOR_EXECUTE))


### PR DESCRIPTION
We found a bug with concurrent queries against the websocket api. If you use a ExaConnection in two concurrent threads to execute queries, we receive similar error messages from the database as the following one:

`Received packet type not expected while command execution. (Session: XXXXXXXX)`

The websocket api doesn't support concurrent requests for a connection. This change adds a lock around the req method which ensures a sequential execution of the queries. Furthermore, we added tests which reproduce the bug when the lock is not used.