### PR TITLE
Set autocommit & query_timeout from attributes

### DIFF
--- a/pyexasol/connection.py
+++ b/pyexasol/connection.py
@@ -399,6 +399,8 @@ class ExaConnection(object):
         })
 
         self.attr = ret['attributes']
+        self.autocommit = self.attr['autocommit']
+        self.query_timeout = self.attr['query_timeout']
 
     def set_attr(self, new_attr):
         self.req({


### PR DESCRIPTION
At the moment the `ExaConnection.autocommit` &
`ExaConnection.query_timeout` can desync from what is set on the Exasol
server, this can lead to confusion. e.g.

```python
import pyexasol
import _config as config

C = pyexasol.connect(config.dsn, user.config.user, password=config.password,
                     autocommit=False)
C.set_autocommit(False)
assert C.attr['autocommit'] is False  # Works
assert C.autocommit is False  # Fails.
```

Here this inconsistency is fixed by setting the `autocommit` &
`query_timeout` from the attributes every time we get them.