### PR TITLE
Feature/add option to return rows as named tuples

### DIFF
--- a/pyexasol/connection.py
+++ b/pyexasol/connection.py
@@ -53,6 +53,7 @@ class ExaConnection(object):
             , encryption=False
             , fetch_dict=False
             , fetch_mapper=None
+            , named_tuples=False
             , fetch_size_bytes=constant.DEFAULT_FETCH_SIZE_BYTES
             , lower_ident=False
             , quote_ident=False
@@ -81,6 +82,7 @@ class ExaConnection(object):
         :param encryption: Use SSL to encrypt client-server communications for WebSocket and HTTP transport (Default: False)
         :param fetch_dict: Fetch result rows as dicts instead of tuples (Default: False)
         :param fetch_mapper: Use custom mapper function to convert Exasol values into Python objects during fetching (Default: None)
+        :param named_tuples: return rows as namedtuples with column names instead of plain tuples (Default: False)
         :param fetch_size_bytes: Maximum size of data message for single fetch request in bytes (Default: 5Mb)
         :param lower_ident: Automatically lowercase identifiers (table names, column names, etc.) returned from relevant functions (Default: False)
         :param quote_ident: Add double quotes and escape identifiers passed to relevant functions (export_*, import_*, ext.*, etc.) (Default: False)
@@ -111,6 +113,7 @@ class ExaConnection(object):
 
             'fetch_dict': fetch_dict,
             'fetch_mapper': fetch_mapper,
+            'named_tuples': named_tuples,
             'fetch_size_bytes': fetch_size_bytes,
             'lower_ident': lower_ident,
             'quote_ident': quote_ident,

--- a/pyexasol/statement.py
+++ b/pyexasol/statement.py
@@ -12,6 +12,7 @@ class ExaStatement(object):
 
         self.fetch_dict = options.get('fetch_dict', self.connection.options['fetch_dict'])
         self.fetch_mapper = options.get('fetch_mapper', self.connection.options['fetch_mapper'])
+        self.named_tuples = options.get('named_tuples', self.connection.options['named_tuples'])
         self.fetch_size_bytes = options.get('fetch_size_bytes', self.connection.options['fetch_size_bytes'])
         self.lower_ident = options.get('lower_ident', self.connection.options['lower_ident'])
 
@@ -63,6 +64,10 @@ class ExaStatement(object):
 
         if self.fetch_mapper:
             row = tuple(map(self.fetch_mapper, row, self.col_types))
+
+        if self.named_tuples:
+            Row = collections.namedtuple('Row', self.col_names, rename=True)
+            row = Row(*row)
 
         if self.fetch_dict:
             row = dict(zip(self.col_names, row))


### PR DESCRIPTION
With this change, users can optionally request that rows are returned as namedtuples, with column names being the namedtuple field names