### PR TITLE
Add context manager for ExaConnection and ExaStatement

### DIFF
--- a/pyexasol/connection.py
+++ b/pyexasol/connection.py
@@ -155,6 +155,12 @@ class ExaConnection(object):
         self._login()
         self.get_attr()
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
     def execute(self, query, query_params=None) -> ExaStatement:
         """
         Execute SQL query with optional query formatting parameters

--- a/pyexasol/statement.py
+++ b/pyexasol/statement.py
@@ -46,6 +46,12 @@ class ExaStatement(object):
         else:
             self._execute()
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
     def __iter__(self):
         return self
 


### PR DESCRIPTION
I'm using pyexasol in some production environment. There is a need to close connections and statements properly to avoid idle ones occupying too much memory on the Exasol cluster.
I added the context manager so that instead of
```python
try:
    conn = pyexasol.connect(...)
    # do something
finally:
    if conn:
        conn.close()
```
we can write
```python
with pyexasol.connect(...) as conn:
    # do something
```