### PR TITLE
Use f-strings for formatting enforcing conversion of values to string

### DIFF
--- a/pyexasol/exceptions.py
+++ b/pyexasol/exceptions.py
@@ -29,7 +29,7 @@ class ExaError(Exception):
         res = ''
 
         for k in params:
-            res += (' ' * 4) + k.ljust(pad_length) + '  =>  ' + params[k] + '\n'
+            res += f"    {k.ljust(pad_length)}  =>  {params[k]}\n"
 
         return '\n(\n' + res + ')\n'
 


### PR DESCRIPTION
For instance, allows to mock the `ExaConnection` object as:

```m_connection = MagicMock(autospec=ExaConnection)```