### PR TITLE
Map INTERVAL DAY TO SECOND to datetime.timedelta

### DIFF
--- a/examples/00_prepare.py
+++ b/examples/00_prepare.py
@@ -10,6 +10,7 @@ import datetime
 import random
 import string
 import decimal
+import pprint
 
 bool_values = [True, False]
 user_statuses = ['ACTIVE', 'PENDING', 'SUSPENDED', 'DISABLED']
@@ -193,15 +194,18 @@ CREATE OR REPLACE TABLE interval_test
 )
 """)
 
-C.execute("""
-INSERT INTO interval_test (id, from_ts, to_ts, expected_timedelta) VALUES
-  (1, '2021-01-10', '2021-01-09',              'datetime.timedelta(days=-1)'),
-  (2, '2021-01-10', '2021-01-09 17:35:11.297', 'datetime.timedelta(days=-1, seconds=63311, microseconds=297000)'),
-  (3, '2021-01-10', '2021-01-10',              'datetime.timedelta(0)'),
-  (4, '2021-01-10', '2021-01-10 17:35:11.297', 'datetime.timedelta(seconds=63311, microseconds=297000)'),
-  (5, '2021-01-10', '2021-01-11',              'datetime.timedelta(days=1)'),
-  (6, '2021-01-10', '2021-01-11 17:35:11.297', 'datetime.timedelta(days=1, seconds=63311, microseconds=297000)')
-""")
+interval_timestamps = [
+    {"from": datetime.datetime(2021, 1, 10), "to": datetime.datetime(2021, 1, 9, 17, 35, 11, 297000)},
+    {"from": datetime.datetime(2021, 1, 10), "to": datetime.datetime(2021, 1, 10)},
+    {"from": datetime.datetime(2021, 1, 10), "to": datetime.datetime(2021, 1, 10, 17, 35, 11, 297000)},
+    {"from": datetime.datetime(2021, 1, 10), "to": datetime.datetime(2021, 1, 11)},
+    {"from": datetime.datetime(2021, 1, 10), "to": datetime.datetime(2021, 1, 11, 17, 35, 11, 297000)},
+    {"from": datetime.datetime(2021, 1, 10), "to": datetime.datetime(2021, 1, 9, 17, 35, 11, 297000)},
+]
+
+for id, ts in enumerate(interval_timestamps):
+    delta = pprint.pformat(ts["to"] - ts["from"])
+    C.execute(f"INSERT INTO interval_test VALUES ({id}, '{ts['from']}', '{ts['to']}', '{delta}')")
 
 C.commit()
 print("Test data was prepared")

--- a/examples/00_prepare.py
+++ b/examples/00_prepare.py
@@ -4,6 +4,7 @@ Prepare tables and data for other examples
 """
 
 import pyexasol
+from pyexasol import ExaTimeDelta
 import _config as config
 
 import datetime
@@ -204,7 +205,7 @@ interval_timestamps = [
 ]
 
 for id, ts in enumerate(interval_timestamps):
-    delta = pprint.pformat(ts["to"] - ts["from"])
+    delta = pprint.pformat(ExaTimeDelta.from_timedelta(ts["to"] - ts["from"]))
     C.execute(f"INSERT INTO interval_test VALUES ({id}, '{ts['from']}', '{ts['to']}', '{delta}')")
 
 C.commit()

--- a/examples/00_prepare.py
+++ b/examples/00_prepare.py
@@ -183,5 +183,25 @@ class SLEEP_JAVA {
 }
 """)
 
+C.execute("""
+CREATE OR REPLACE TABLE interval_test
+(
+    id INTEGER,
+    from_ts TIMESTAMP,
+    to_ts TIMESTAMP,
+    expected_timedelta VARCHAR(100)
+)
+""")
+
+C.execute("""
+INSERT INTO interval_test (id, from_ts, to_ts, expected_timedelta) VALUES
+  (1, '2021-01-10', '2021-01-09',              'datetime.timedelta(days=-1)'),
+  (2, '2021-01-10', '2021-01-09 17:35:11.297', 'datetime.timedelta(days=-1, seconds=63311, microseconds=297000)'),
+  (3, '2021-01-10', '2021-01-10',              'datetime.timedelta(0)'),
+  (4, '2021-01-10', '2021-01-10 17:35:11.297', 'datetime.timedelta(seconds=63311, microseconds=297000)'),
+  (5, '2021-01-10', '2021-01-11',              'datetime.timedelta(days=1)'),
+  (6, '2021-01-10', '2021-01-11 17:35:11.297', 'datetime.timedelta(days=1, seconds=63311, microseconds=297000)')
+""")
+
 C.commit()
 print("Test data was prepared")

--- a/examples/04_fetch_mapper.py
+++ b/examples/04_fetch_mapper.py
@@ -2,15 +2,16 @@
 Example 4
 Using custom mapper to get python objects out of Exasol fetch methods
 
-DECIMAL(p,0) -> int
-DECIMAL(p,s) -> decimal.Decimal
-DOUBLE       -> float
-DATE         -> datetime.date
-TIMESTAMP    -> datetime.datetime
-BOOLEAN      -> bool
-VARCHAR      -> str
-CHAR         -> str
-<others>     -> str
+DECIMAL(p,0)           -> int
+DECIMAL(p,s)           -> decimal.Decimal
+DOUBLE                 -> float
+DATE                   -> datetime.date
+TIMESTAMP              -> datetime.datetime
+BOOLEAN                -> bool
+VARCHAR                -> str
+CHAR                   -> str
+INTERVAL DAY TO SECOND -> datetime.timedelta
+<others>               -> str
 """
 
 import pyexasol
@@ -34,3 +35,14 @@ printer.pprint(stmt.fetchall())
 for i in range(0, 9):
     C.execute(f"ALTER SESSION SET NLS_TIMESTAMP_FORMAT='YYYY-MM-DD HH24:MI:SS.FF{i}'")
     printer.pprint(C.execute("SELECT TIMESTAMP'2018-01-01 03:04:05.123456'").fetchval())
+
+# Test interval mapping
+stmt = C.execute("SELECT id, from_ts, to_ts, expected_timedelta, to_ts - from_ts AS actual_timedelta FROM interval_test")
+for row in stmt.fetchall():
+    actual = printer.pformat(row[4])
+    print(f"---- Interval Test #{row[0]} ----")
+    print(f"    FROM: {row[1]}")
+    print(f"      TO: {row[2]}")
+    print(f"EXPECTED: {row[3]}")
+    print(f"  ACTUAL: {actual} " + ("✓" if actual == row[3] else "✗"))
+    assert actual == row[3], f"actual timedelta '{actual}' doesn't match expected timedelta '{row[3]}'"

--- a/examples/04_fetch_mapper.py
+++ b/examples/04_fetch_mapper.py
@@ -37,12 +37,22 @@ for i in range(0, 9):
     printer.pprint(C.execute("SELECT TIMESTAMP'2018-01-01 03:04:05.123456'").fetchval())
 
 # Test interval mapping
-stmt = C.execute("SELECT id, from_ts, to_ts, expected_timedelta, to_ts - from_ts AS actual_timedelta FROM interval_test")
+stmt = C.execute("SELECT id, from_ts, to_ts, expected_timedelta, cast(to_ts - from_ts as varchar(100)) as expected_interval, to_ts - from_ts AS ts_diff FROM interval_test")
 for row in stmt.fetchall():
-    actual = printer.pformat(row[4])
-    print(f"---- Interval Test #{row[0]} ----")
-    print(f"    FROM: {row[1]}")
-    print(f"      TO: {row[2]}")
-    print(f"EXPECTED: {row[3]}")
-    print(f"  ACTUAL: {actual} " + ("✓" if actual == row[3] else "✗"))
-    assert actual == row[3], f"actual timedelta '{actual}' doesn't match expected timedelta '{row[3]}'"
+    print(f"-------- Interval Test #{row[0]} --------")
+    print(f"              FROM: {row[1]}")
+    print(f"                TO: {row[2]}")
+
+    print(f"EXPECTED TIMEDELTA: {row[3]}")
+    actual_timedelta = printer.pformat(row[5])
+    if actual_timedelta == row[3]:
+        print(f"  \033[1;32mACTUAL TIMEDELTA: {actual_timedelta} ✓\033[0m")
+    else:
+        print(f"  \033[1;31mACTUAL TIMEDELTA: {actual_timedelta} ✗\033[0m")
+
+    print(f" EXPECTED INTERVAL: {row[4]}")
+    actual_interval = row[5].to_interval()
+    if actual_interval == row[4]:
+        print(f"   \033[1;32mACTUAL INTERVAL: {actual_interval} ✓\033[0m")
+    else:
+        print(f"   \033[1;31mACTUAL INTERVAL: {actual_interval} ✗\033[0m")

--- a/pyexasol/__init__.py
+++ b/pyexasol/__init__.py
@@ -25,6 +25,7 @@ __all__ = [
     'ExaMetaData',
     'ExaHTTPTransportWrapper',
     'ExaLocalConfig',
+    'ExaTimeDelta',
     'HTTP_EXPORT',
     'HTTP_IMPORT',
     'PROTOCOL_V1',
@@ -40,7 +41,7 @@ from .local_config import ExaLocalConfig
 from .logger import ExaLogger
 from .ext import ExaExtension
 from .meta import ExaMetaData
-from .mapper import exasol_mapper
+from .mapper import ExaTimeDelta, exasol_mapper
 from .http_transport import ExaHTTPTransportWrapper, HTTP_EXPORT, HTTP_IMPORT
 from .constant import PROTOCOL_V1, PROTOCOL_V2
 

--- a/pyexasol/mapper.py
+++ b/pyexasol/mapper.py
@@ -2,6 +2,66 @@ import decimal
 import datetime
 
 
+class ExaTimeDelta(datetime.timedelta):
+    def __new__(cls, *args, **kwargs):
+        return super(ExaTimeDelta, cls).__new__(cls, *args, **kwargs)
+
+    def reverse_seconds(self):
+        if self.microseconds > 0:
+            seconds = 86399 - self.seconds
+            microseconds = 1000000 - self.microseconds
+        elif self.seconds > 0:
+            seconds = 86400 - self.seconds
+            microseconds = 0
+        else:
+            seconds = 0
+            microseconds = 0
+        return (seconds, microseconds)
+
+    @classmethod
+    def from_interval(cls, val):
+        td = cls(
+            days=int(val[0:10]),
+            hours=int(val[11:13]),
+            minutes=int(val[14:16]),
+            seconds=int(val[17:19]),
+            microseconds=int(round(float(val[20:29].ljust(9, '0')) / 1000)) if len(val) > 20 else 0,
+        )
+        if val[0] == '-':
+            # normalize according to Python timedelta rules (days are negative; remaining parts apply back "up" towards 0)
+            # - eg. -6 days, 1:00:00.000000 would represent 5 days, 23 hours ago (6 days back, 1 hour forward)
+            (seconds, microseconds) = td.reverse_seconds()
+            if seconds or microseconds:
+                td = cls(days=td.days - 1, seconds=seconds, microseconds=microseconds)
+            else:
+                td = cls(days=td.days, seconds=seconds, microseconds=microseconds)
+        return td
+
+    @classmethod
+    def from_timedelta(cls, td):
+        return cls(days=td.days, seconds=td.seconds, microseconds=td.microseconds)
+
+    def to_interval(self):
+        if self.days < 0:
+            (seconds, microseconds) = self.reverse_seconds()
+            if seconds or microseconds:
+                s = "-%09d " % (abs(self.days) - 1,)
+            else:
+                s = "-%09d " % (abs(self.days) - 1,)
+        else:
+            seconds = self.seconds
+            microseconds = self.microseconds
+            s = "+%09d " % (self.days,)
+
+        mm, ss = divmod(seconds, 60)
+        hh, mm = divmod(mm, 60)
+        s = s + "%02d:%02d:%02d.%09d" % (hh, mm, ss, microseconds * 1000)
+        return s
+
+    def __str__(self):
+        return self.to_interval()
+
+
 def exasol_mapper(val, data_type):
     """
     Convert into Python 3 data types according to Exasol manual
@@ -35,31 +95,6 @@ def exasol_mapper(val, data_type):
                                  int(val[11:13]), int(val[14:16]), int(val[17:19]),      # hour, minute, second
                                  int(val[20:26].ljust(6, '0')) if len(val) > 20 else 0)  # microseconds (if available)
     elif data_type['type'] == 'INTERVAL DAY TO SECOND':
-        td = datetime.timedelta(
-            days=int(val[0:10]),
-            hours=int(val[11:13]),
-            minutes=int(val[14:16]),
-            seconds=int(val[17:19]),
-            microseconds=int(round(float(val[20:29].ljust(9, '0')) / 1000)) if len(val) > 20 else 0,
-        )
-        if val[0] == '-':
-            # normalize according to Python timedelta rules (days are negative; remaining parts apply back "up" towards 0)
-            # - eg. -6 days, 1:00:00.000000 would represent 5 days, 23 hours ago (6 days back, 1 hour forward)
-            if td.microseconds > 0:
-                seconds = 86399 - td.seconds
-                microseconds = 1000000 - td.microseconds
-                sub_days = 1
-            elif td.seconds > 0:
-                seconds = 86400 - td.seconds
-                microseconds = 0
-                sub_days = 1
-            else:
-                seconds = 0
-                microseconds = 0
-                sub_days = 0
-            td = datetime.timedelta(
-                days=td.days - sub_days, seconds=seconds, microseconds=microseconds
-            )
-        return td
+        return ExaTimeDelta.from_interval(val)
     else:
         return val

--- a/pyexasol/mapper.py
+++ b/pyexasol/mapper.py
@@ -9,15 +9,16 @@ def exasol_mapper(val, data_type):
     strptime() function is slow, so we use direct string slicing for performance sake
     More details about this problem: http://ze.phyr.us/faster-strptime/
 
-    DECIMAL(p,0) -> int
-    DECIMAL(p,s) -> decimal.Decimal
-    DOUBLE       -> float
-    DATE         -> datetime.date
-    TIMESTAMP    -> datetime.datetime
-    BOOLEAN      -> bool
-    VARCHAR      -> str
-    CHAR         -> str
-    <others>     -> str
+    DECIMAL(p,0)           -> int
+    DECIMAL(p,s)           -> decimal.Decimal
+    DOUBLE                 -> float
+    DATE                   -> datetime.date
+    TIMESTAMP              -> datetime.datetime
+    BOOLEAN                -> bool
+    VARCHAR                -> str
+    CHAR                   -> str
+    INTERVAL DAY TO SECOND -> datetime.timedelta
+    <others>               -> str
     """
 
     if val is None:
@@ -33,5 +34,32 @@ def exasol_mapper(val, data_type):
         return datetime.datetime(int(val[0:4]), int(val[5:7]), int(val[8:10]),           # year, month, day
                                  int(val[11:13]), int(val[14:16]), int(val[17:19]),      # hour, minute, second
                                  int(val[20:26].ljust(6, '0')) if len(val) > 20 else 0)  # microseconds (if available)
+    elif data_type['type'] == 'INTERVAL DAY TO SECOND':
+        td = datetime.timedelta(
+            days=int(val[0:10]),
+            hours=int(val[11:13]),
+            minutes=int(val[14:16]),
+            seconds=int(val[17:19]),
+            microseconds=int(round(float(val[20:29].ljust(9, '0')) / 1000)) if len(val) > 20 else 0,
+        )
+        if val[0] == '-':
+            # normalize according to Python timedelta rules (days are negative; remaining parts apply back "up" towards 0)
+            # - eg. -6 days, 1:00:00.000000 would represent 5 days, 23 hours ago (6 days back, 1 hour forward)
+            if td.microseconds > 0:
+                seconds = 86399 - td.seconds
+                microseconds = 1000000 - td.microseconds
+                sub_days = 1
+            elif td.seconds > 0:
+                seconds = 86400 - td.seconds
+                microseconds = 0
+                sub_days = 1
+            else:
+                seconds = 0
+                microseconds = 0
+                sub_days = 0
+            td = datetime.timedelta(
+                days=td.days - sub_days, seconds=seconds, microseconds=microseconds
+            )
+        return td
     else:
         return val


### PR DESCRIPTION
I've recently needed to map INTERVALs from Exasol, and thought it might be a useful contribution to the core PyEXASOL code.

There's some interesting logic in how Python manages negative timedeltas, essentially subtracting an additional day and then always adding back the seconds + microseconds: https://docs.python.org/3/library/datetime.html#timedelta-objects

I didn't see any "regular" tests, so I added some interval checks to the examples code, with an assert that will raise if there's a mismatch.