### PR TITLE
Expand Exasol test version matrix

### DIFF
--- a/doc/changes/unreleased.md
+++ b/doc/changes/unreleased.md
@@ -5,3 +5,4 @@
 ## Refactoring
 
 * #354: Updated to `exasol-toolbox` 10.4.0
+* #723: Added integration-test coverage for Exasol 2025.1.11 and 2026.1.0

--- a/noxconfig.py
+++ b/noxconfig.py
@@ -86,5 +86,5 @@ PROJECT_CONFIG = Config(
     # & a known issue in the ITDE & will be resolved in:
     #   https://github.com/exasol/pyexasol/issues/285
     python_versions=("3.10", "3.11", "3.12", "3.13"),
-    exasol_versions=("8.29.13", "2025.1.11", "2026.1.0"),
+    exasol_versions=("8.29.13", "2025.1.11", DEFAULT_DB_VERSION),
 )

--- a/noxconfig.py
+++ b/noxconfig.py
@@ -10,7 +10,7 @@ from pydantic import (
 )
 
 DEFAULT_PORT = 8563
-DEFAULT_DB_VERSION = "8.29.13"
+DEFAULT_DB_VERSION = "2026.1.0"
 CONTAINER_SUFFIX = "test"
 CONTAINER_NAME = f"db_container_{CONTAINER_SUFFIX}"
 
@@ -86,7 +86,5 @@ PROJECT_CONFIG = Config(
     # & a known issue in the ITDE & will be resolved in:
     #   https://github.com/exasol/pyexasol/issues/285
     python_versions=("3.10", "3.11", "3.12", "3.13"),
-    # Changes for 2025.1.x have not yet been made. This will be resolved in:
-    #   https://github.com/exasol/pyexasol/issues/273
-    exasol_versions=("8.29.13",),
+    exasol_versions=("8.29.13", "2025.1.11", "2026.1.0"),
 )

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -306,6 +306,8 @@ def expected_reserved_words(db_major_version):
         return set_shared
     elif db_major_version >= 8:
         set_shared.update(["CURRENT_CLUSTER", "CURRENT_CLUSTER_UID"])
+        if db_major_version >= 2025:
+            set_shared.add("PARQUET")
         return set_shared
 
 

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -304,7 +304,7 @@ def expected_reserved_words(db_major_version):
 
     if db_major_version == 7:
         return set_shared
-    elif db_major_version == 8:
+    elif db_major_version >= 8:
         set_shared.update(["CURRENT_CLUSTER", "CURRENT_CLUSTER_UID"])
         return set_shared
 
@@ -315,7 +315,7 @@ def expected_user_table_column_last_visit_ts(db_major_version):
 
     if db_major_version == 7:
         return timestamp_type(size=8, sql_type="TIMESTAMP")
-    elif db_major_version == 8:
+    elif db_major_version >= 8:
         return timestamp_type(size=16, sql_type="TIMESTAMP(3)")
 
 


### PR DESCRIPTION
closes #273 

## Summary

- retain Exasol 8.29.13 coverage and add 2025.1.11 and 2026.1.0
- make 2026.1.0 the default database version for local Nox database starts
- apply the established 8.x metadata expectations to all database versions 8 and newer

## Why

The integration-test fixtures only handled database major versions 7 and 8. On 2025.1.11 this produced `None` expected values for metadata assertions, causing the failures observed in the linked Actions run.

## Validation

- `python3 -m compileall -q noxconfig.py test/integration/conftest.py`
- `git diff --check`

Full Nox integration tests were not run locally because the Poetry environment did not have the `nox` executable installed.